### PR TITLE
Moved react-native and other dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,8 @@
   "dependencies": {
     "@expo/match-media": "^0.0.0-beta.2",
     "axios": "^0.21.1",
-    "expo": "~40.0.0",
-    "expo-status-bar": "~1.0.3",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.0.tar.gz",
     "react-native-svg": "12.1.0",
-    "react-native-web": "~0.13.12",
-    "react-responsive": "^8.2.0",
-    "rc-progress":"^3.1.3"
+    "react-responsive": "^8.2.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",
@@ -30,6 +23,15 @@
     "@types/react-native": "~0.63.2",
     "@types/react-responsive": "^8.0.2",
     "@types/react-test-renderer": "^17.0.1",
+
+    "expo": "~40.0.0",
+    "expo-status-bar": "~1.0.3",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.0.tar.gz",
+    "react-native-web": "~0.13.12",
+    "rc-progress":"^3.1.3",
+
     "jest-expo": "^40.0.2",
     "metro-react-native-babel-preset": "^0.65.0",
     "react-test-renderer": "^17.0.1",


### PR DESCRIPTION
This PR moves around some dependencies so the implementer is not pinned to specific versions of things. 

I was running into an issue where I was on react-native 0.64.2, which was causing a conflict with the metro-config in https://github.com/expo/react-native/archive/sdk-40.0.0.tar.gz. 

